### PR TITLE
Fixed protocol for autoreload.js

### DIFF
--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -3,10 +3,10 @@
     protocol =
         protocol === 'auto'
             ? window.location.protocol === 'https:'
-                ? 'wss:'
-                : 'ws:'
+                ? 'wss'
+                : 'ws'
             : protocol
-    var url = protocol + '//' + '{{__TRUNK_ADDRESS__}}' + '/_trunk/ws';
+    var url = protocol + '://' + '{{__TRUNK_ADDRESS__}}' + '/_trunk/ws';
     var poll_interval = 5000;
     var reload_upon_connect = () => {
         window.setTimeout(


### PR DESCRIPTION
The change is simple, always add the `:` instead and don't add it when it's in "auto" mode.